### PR TITLE
🔧fix: replace throw exception with log error

### DIFF
--- a/src/DymoAPI.php
+++ b/src/DymoAPI.php
@@ -109,8 +109,8 @@ class DymoAPI {
         if (empty($tokens)) return;
         try {
             $response = $this->postRequest("/v1/dvr/tokens", ["tokens" => $tokens]);
-            if ($this->rootApiKey && (!isset($response["root"]) || $response["root"] === false)) return error_log("Invalid root token.\n", 3, $this->errorLogRoute);
-            if ($this->apiKey && (!isset($response["private"]) || $response["private"] === false)) return error_log("Invalid private token.\n", 3, $this->errorLogRoute);
+            if ($this->rootApiKey && (!isset($response["root"]) || $response["root"] === false)) throw new AuthenticationError("Invalid root token.");
+            if ($this->apiKey && (!isset($response["private"]) || $response["private"] === false)) throw new AuthenticationError("Invalid private token.");
             self::$tokensResponse = $response;
             self::$tokensVerified = true;
         } catch (Exception $e) {


### PR DESCRIPTION
# Title
Handle authentication errors in DymoAPI without crashing api

## Description:
This PR improves the handling of authentication errors in the DymoAPI class. Instead of causing the application to crash when the API is down or there’s an error verifying tokens, these errors are now caught and logged as warnings or using console.error, ensuring the application continues to function.

## Changes
- Authentication Error Handling: removed to capture exceptions during authentication and token verification processes.
- Logging Warnings and Errors: Utilized logging.warning and logging.error (or an equivalent logging function) to log errors instead of letting the application crash.

## How to Test It:
- Simulate an authentication API downtime.
- Attempt to authenticate and verify tokens during this scenario.
- Verify that the errors are logged and the application does not crash.